### PR TITLE
Remove unused i2c, is actually uart

### DIFF
--- a/test.yaml
+++ b/test.yaml
@@ -26,11 +26,6 @@ api:
 
 ota:
 
-i2c:
-  sda: GPIO2
-  scl: GPIO14
-  scan: false
-
 # Example configuration entry
 
 wled:


### PR DESCRIPTION
fixes https://github.com/dckiller51/esphome-yeelight-led-screen-light-bar/issues/12